### PR TITLE
Mainly add missing files palloc.h and palloc.c in palloc-3.15.patch

### DIFF
--- a/palloc-3.15.patch
+++ b/palloc-3.15.patch
@@ -49,8 +49,47 @@ index fac5509..3656155 100644
  #ifndef CONFIG_SPARSEMEM
  	/*
  	 * Flags for a pageblock_nr_pages block. See pageblock-flags.h.
+diff --git a/include/linux/palloc.h b/include/linux/palloc.h
+new file mode 100644
+index 0000000..ec4c092
+--- /dev/null
++++ b/include/linux/palloc.h
+@@ -0,0 +1,33 @@
++#ifndef _LINUX_PALLOC_H
++#define _LINUX_PALLOC_H
++
++/*
++ * kernel/palloc.h
++ *
++ * PHysical memory aware allocator
++ */
++
++#include <linux/types.h>
++#include <linux/cgroup.h>
++#include <linux/kernel.h>
++#include <linux/mm.h>
++
++#ifdef CONFIG_CGROUP_PALLOC
++
++struct palloc {
++	struct cgroup_subsys_state css;
++	COLOR_BITMAP(cmap);
++};
++
++/* Retrieve the palloc group corresponding to this cgroup container */
++struct palloc *cgroup_ph(struct cgroup *cgrp);
++
++/* Retrieve the palloc group corresponding to this subsys */
++struct palloc * ph_from_subsys(struct cgroup_subsys_state * subsys);
++
++/* return #of palloc bins */
++int palloc_bins(void);
++
++#endif /* CONFIG_CGROUP_PALLOC */
++
++#endif /* _LINUX_PALLOC_H */
 diff --git a/init/Kconfig b/init/Kconfig
-index 9d3585b..71cafd1 100644
+index 765018c..84776c1 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1089,6 +1089,12 @@ config DEBUG_BLK_CGROUP
@@ -77,7 +116,7 @@ index b484452..cc1e594 100644
 +obj-$(CONFIG_CGROUP_PALLOC) += palloc.o
 +
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index a5194ab..7471b2c 100644
+index 5dba293..b5b0f09 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -1,3 +1,4 @@
@@ -280,7 +319,7 @@ index a5194ab..7471b2c 100644
  
  #ifdef CONFIG_USE_PERCPU_NUMA_NODE_ID
  DEFINE_PER_CPU(int, numa_node);
-@@ -920,12 +1103,314 @@ static int prep_new_page(struct page *page, int order, gfp_t gfp_flags)
+@@ -907,12 +1090,314 @@ static int prep_new_page(struct page *page, int order, gfp_t gfp_flags)
  	return 0;
  }
  
@@ -595,7 +634,7 @@ index a5194ab..7471b2c 100644
  						int migratetype)
  {
  	unsigned int current_order;
-@@ -949,7 +1434,7 @@ struct page *__rmqueue_smallest(struct zone *zone, unsigned int order,
+@@ -936,7 +1421,7 @@ struct page *__rmqueue_smallest(struct zone *zone, unsigned int order,
  
  	return NULL;
  }
@@ -604,7 +643,7 @@ index a5194ab..7471b2c 100644
  
  /*
   * This array describes the order lists are fallen back to when
-@@ -1541,9 +2026,13 @@ struct page *buffered_rmqueue(struct zone *preferred_zone,
+@@ -1528,9 +2013,13 @@ struct page *buffered_rmqueue(struct zone *preferred_zone,
  	unsigned long flags;
  	struct page *page;
  	int cold = !!(gfp_flags & __GFP_COLD);
@@ -619,7 +658,7 @@ index a5194ab..7471b2c 100644
  		struct per_cpu_pages *pcp;
  		struct list_head *list;
  
-@@ -4109,6 +4598,15 @@ void __meminit memmap_init_zone(unsigned long size, int nid, unsigned long zone,
+@@ -4096,6 +4585,15 @@ void __meminit memmap_init_zone(unsigned long size, int nid, unsigned long zone,
  static void __meminit zone_init_free_lists(struct zone *zone)
  {
  	int order, t;
@@ -635,7 +674,7 @@ index a5194ab..7471b2c 100644
  	for_each_migratetype_order(order, t) {
  		INIT_LIST_HEAD(&zone->free_area[order].free_list[t]);
  		zone->free_area[order].nr_free = 0;
-@@ -6439,6 +6937,9 @@ __offline_isolated_pages(unsigned long start_pfn, unsigned long end_pfn)
+@@ -6420,6 +6918,9 @@ __offline_isolated_pages(unsigned long start_pfn, unsigned long end_pfn)
  		return;
  	zone = page_zone(pfn_to_page(pfn));
  	spin_lock_irqsave(&zone->lock, flags);
@@ -645,6 +684,178 @@ index a5194ab..7471b2c 100644
  	pfn = start_pfn;
  	while (pfn < end_pfn) {
  		if (!pfn_valid(pfn)) {
+diff --git a/mm/palloc.c b/mm/palloc.c
+new file mode 100644
+index 0000000..b9acae1
+--- /dev/null
++++ b/mm/palloc.c
+@@ -0,0 +1,166 @@
++/*
++ * kernel/palloc.c
++ *
++ * Physical driven User Space Allocator info for a set of tasks.
++ */
++
++#include <linux/types.h>
++#include <linux/cgroup.h>
++#include <linux/kernel.h>
++#include <linux/slab.h>
++#include <linux/palloc.h>
++#include <linux/mm.h>
++#include <linux/err.h>
++#include <linux/fs.h>
++#include <linux/bitmap.h>
++#include <linux/module.h>
++
++/*
++ * Check if a page is compliant to the policy defined for the given vma
++ */
++#ifdef CONFIG_CGROUP_PALLOC
++
++#define MAX_LINE_LEN (6*128)
++/*
++ * Types of files in a palloc group
++ * FILE_PALLOC - contain list of palloc bins allowed
++*/
++typedef enum {
++	FILE_PALLOC,
++} palloc_filetype_t;
++
++/*
++ * Top level palloc - mask initialized to zero implying no restriction on
++ * physical pages
++*/
++
++static struct palloc top_palloc;
++
++/* Retrieve the palloc group corresponding to this cgroup container */
++struct palloc *cgroup_ph(struct cgroup *cgrp)
++{
++	return container_of(cgrp->subsys[palloc_cgrp_id],
++			    struct palloc, css);
++}
++
++struct palloc * ph_from_subsys(struct cgroup_subsys_state * subsys)
++{
++	return container_of(subsys, struct palloc, css);
++}
++
++/*
++ * Common write function for files in palloc cgroup
++ */
++static int update_bitmask(unsigned long *bitmap, const char *buf, int maxbits)
++{
++	int retval = 0;
++
++	if (!*buf)
++		bitmap_clear(bitmap, 0, maxbits);
++	else
++		retval = bitmap_parselist(buf, bitmap, maxbits);
++
++	return retval;
++}
++
++
++static int palloc_file_write(struct cgroup_subsys_state *css, struct cftype *cft,
++                char *buffer)
++{
++	int retval = 0;
++	struct palloc *ph = container_of(css, struct palloc, css);
++
++	switch (cft->private) {
++	case FILE_PALLOC:
++		retval = update_bitmask(ph->cmap, buffer, palloc_bins());
++		printk(KERN_INFO "Bins : %s\n", buffer);
++		break;
++	default:
++		retval = -EINVAL;
++		break;
++	}
++
++	return retval;
++}
++
++static int palloc_file_read(struct seq_file *sf, void *v)
++{
++	struct cgroup_subsys_state *css = seq_css(sf);
++	struct cftype *cft = seq_cft(sf);
++	struct palloc *ph = container_of(css, struct palloc, css);
++	char *page;
++	ssize_t retval = 0;
++	char *s;
++
++	if (!(page = (char *)__get_free_page(GFP_TEMPORARY|__GFP_ZERO)))
++		return -ENOMEM;
++
++	s = page;
++
++	switch (cft->private) {
++	case FILE_PALLOC:
++		s += bitmap_scnlistprintf(s, PAGE_SIZE, ph->cmap, palloc_bins());
++		*s++ = '\n';
++		printk(KERN_INFO "Bins : %s", page);
++		break;
++	default:
++		retval = -EINVAL;
++		goto out;
++	}
++
++	retval = seq_printf(sf, "%s", page);
++out:
++	free_page((unsigned long)page);
++	return retval;
++}
++
++
++/*
++ * struct cftype: handler definitions for cgroup control files
++ *
++ * for the common functions, 'private' gives the type of the file
++ */
++static struct cftype files[] = {
++	{
++		.name = "bins",
++		.seq_show = palloc_file_read,
++		.write_string = palloc_file_write,
++		.max_write_len = MAX_LINE_LEN,
++		.private = FILE_PALLOC,
++	},
++	{ }	/* terminate */
++};
++
++/*
++ * palloc_create - create a palloc group
++ */
++static struct cgroup_subsys_state *palloc_create(struct cgroup_subsys_state *css)
++{
++	struct palloc * ph_child;
++	ph_child = kmalloc(sizeof(struct palloc), GFP_KERNEL);
++	if(!ph_child)
++		return ERR_PTR(-ENOMEM);
++
++	bitmap_clear(ph_child->cmap, 0, MAX_PALLOC_BINS);
++	return &ph_child->css;
++}
++
++
++/*
++ * Destroy an existing palloc group
++ */
++static void palloc_destroy(struct cgroup_subsys_state *css)
++{
++	struct palloc *ph = container_of(css, struct palloc, css);
++	kfree(ph);
++}
++
++struct cgroup_subsys palloc_cgrp_subsys = {
++	.name = "palloc",
++	.css_alloc = palloc_create,
++	.css_free = palloc_destroy,
++	.id = palloc_cgrp_id,
++	.base_cftypes = files,
++};
++
++#endif /* CONFIG_CGROUP_PALLOC */
 diff --git a/mm/vmstat.c b/mm/vmstat.c
 index 302dd07..b5753cd 100644
 --- a/mm/vmstat.c


### PR DESCRIPTION
This patch does:
    \* add missing files "linux/palloc.h" and "mm/palloc.c".
    \* change read and write operations to "palloc.bins" to the new interface of cgroup.
    \* also fix a bug in palloc-3.13.patch - in function "palloc_file_read" the code :
      "printk(KERN_INFO "Bins : %s\n", s);" doesn't output anything useful;

thanks!
