### PR TITLE
Updating the README.md file w.r.t. huge_page support conflict with palloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ For cache partitioning, just use the cache set bits instead of DRAM bank bits.
         # echo 1 > /sys/kernel/debug/palloc/use_palloc
       	 --> enable palloc (owise the default buddy allocator will be used)
    ```
+2. Disable support for transparent huge pages from kernel:
 
+         # echo never > /sys/kernel/mm/transparent_hugepage/enabled
+   
 ## Papers
 
 * Heechul Yun, Renato, Zheng-Pei Wu, Rodolfo Pellizzoni. "PALLOC: DRAM Bank-Aware Memory Allocator for Performance Isolation on Multicore Platforms," _IEEE Intl. Conference on Real-Time and Embedded Technology and Applications Symposium (RTAS)_, 2014. ([pdf](http://www.ittc.ku.edu/~heechul/papers/palloc-rtas2014.pdf))

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For cache partitioning, just use the cache set bits instead of DRAM bank bits.
    ```
 2. Disable support for transparent huge pages from kernel:
 
-         # echo never > /sys/kernel/mm/transparent_hugepage/enabled
+        # echo never > /sys/kernel/mm/transparent_hugepage/enabled
    
 ## Papers
 


### PR DESCRIPTION
If the huge page support is enabled in kernel, the likelihood of the allocation of higher order pages increases. Since higher order pages are not handled by palloc and instead the buddy allocator takes care of them, this results in the discrepancy in the expected execution results of the benchmarks which are meant to be run with palloc.

In order to circumvent this problem, transparent huge page support should be disabled from the kernel when palloc is running. This commit to the palloc README.md mentions the method of doing so at runtime.
