### PR TITLE
Adding PALLOC PATCH for Linux-4.4.3 Kernel

### DIFF
--- a/palloc-4.4.3.patch
+++ b/palloc-4.4.3.patch
@@ -1,0 +1,935 @@
+diff --git a/include/linux/cgroup_subsys.h b/include/linux/cgroup_subsys.h
+index 1a96fda..9235fae 100644
+--- a/include/linux/cgroup_subsys.h
++++ b/include/linux/cgroup_subsys.h
+@@ -84,3 +84,7 @@ SUBSYS(debug)
+ /*
+  * DO NOT ADD ANY SUBSYSTEM WITHOUT EXPLICIT ACKS FROM CGROUP MAINTAINERS.
+  */
++
++#if IS_ENABLED(CONFIG_CGROUP_PALLOC)
++SUBSYS(palloc)
++#endif
+diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
+index e23a9e7..1f718f09 100644
+--- a/include/linux/mmzone.h
++++ b/include/linux/mmzone.h
+@@ -69,6 +69,14 @@ enum {
+ #  define is_migrate_cma(migratetype) false
+ #endif
+ 
++#ifdef CONFIG_CGROUP_PALLOC
++/* Determine the number of bins according to the bits required for
++   each component of the address */
++#define MAX_PALLOC_BITS 8
++#define MAX_PALLOC_BINS (1 << MAX_PALLOC_BITS)
++#define COLOR_BITMAP(name) DECLARE_BITMAP(name, MAX_PALLOC_BINS)
++#endif
++
+ #define for_each_migratetype_order(order, type) \
+ 	for (order = 0; order < MAX_ORDER; order++) \
+ 		for (type = 0; type < MIGRATE_TYPES; type++)
+@@ -478,6 +486,14 @@ struct zone {
+ 	/* free areas of different sizes */
+ 	struct free_area	free_area[MAX_ORDER];
+ 
++#ifdef CONFIG_CGROUP_PALLOC
++	/*
++	 * Color page cache for movable type free pages of order-0
++	 */
++	struct list_head	color_list[MAX_PALLOC_BINS];
++	COLOR_BITMAP(color_bitmap);
++#endif
++
+ 	/* zone flags, see below */
+ 	unsigned long		flags;
+ 
+diff --git a/include/linux/palloc.h b/include/linux/palloc.h
+new file mode 100644
+index 0000000..7236e31
+--- /dev/null
++++ b/include/linux/palloc.h
+@@ -0,0 +1,33 @@
++#ifndef _LINUX_PALLOC_H
++#define _LINUX_PALLOC_H
++
++/*
++ * kernel/palloc.h
++ *
++ * Physical Memory Aware Allocator
++ */
++
++#include <linux/types.h>
++#include <linux/cgroup.h>
++#include <linux/kernel.h>
++#include <linux/mm.h>
++
++#ifdef CONFIG_CGROUP_PALLOC
++
++struct palloc {
++	struct cgroup_subsys_state css;
++	COLOR_BITMAP(cmap);
++};
++
++/* Retrieve the palloc group corresponding to this cgroup container */
++struct palloc *cgroup_ph(struct cgroup *cgrp);
++
++/* Retrieve the palloc group corresponding to this subsys */
++struct palloc *ph_from_subsys(struct cgroup_subsys_state *subsys);
++
++/* Return number of palloc bins */
++int palloc_bins(void);
++
++#endif /* CONFIG_CGROUP_PALLOC */
++
++#endif /* _LINUX_PALLOC_H */
+diff --git a/init/Kconfig b/init/Kconfig
+index 235c7a2..7008afb 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -1151,6 +1151,13 @@ config CGROUP_WRITEBACK
+ 	depends on MEMCG && BLK_CGROUP
+ 	default y
+ 
++config CGROUP_PALLOC
++	bool "Enable PALLOC"
++	help
++	  Enable PALLOC. PALLOC is a color-aware page-based physical memory
++	  allocator which replaces the buddy allocator for order-zero page
++	  allocations.
++
+ endif # CGROUPS
+ 
+ config CHECKPOINT_RESTORE
+diff --git a/mm/Makefile b/mm/Makefile
+index 2ed4319..e4edf2e 100644
+--- a/mm/Makefile
++++ b/mm/Makefile
+@@ -74,6 +74,7 @@ obj-$(CONFIG_ZPOOL)	+= zpool.o
+ obj-$(CONFIG_ZBUD)	+= zbud.o
+ obj-$(CONFIG_ZSMALLOC)	+= zsmalloc.o
+ obj-$(CONFIG_GENERIC_EARLY_IOREMAP) += early_ioremap.o
++obj-$(CONFIG_CGROUP_PALLOC) += palloc.o
+ obj-$(CONFIG_CMA)	+= cma.o
+ obj-$(CONFIG_MEMORY_BALLOON) += balloon_compaction.o
+ obj-$(CONFIG_PAGE_EXTENSION) += page_ext.o
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+index 9d666df..8519930 100644
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -64,12 +64,200 @@
+ #include <linux/kthread.h>
+ 
+ #include <asm/sections.h>
++#include <linux/debugfs.h>
+ #include <asm/tlbflush.h>
+ #include <asm/div64.h>
+ #include "internal.h"
+ 
+ /* prevent >1 _updater_ of zone percpu pageset ->high and ->batch fields */
+ static DEFINE_MUTEX(pcp_batch_high_lock);
++
++#ifdef CONFIG_CGROUP_PALLOC
++#include <linux/palloc.h>
++
++int memdbg_enable = 0;
++EXPORT_SYMBOL(memdbg_enable);
++
++static int sysctl_alloc_balance = 0;
++
++/* PALLOC address bitmask */
++static unsigned long sysctl_palloc_mask = 0x0;
++
++static int mc_xor_bits[64];
++static int use_mc_xor = 0;
++static int use_palloc = 0;
++
++DEFINE_PER_CPU(unsigned long, palloc_rand_seed);
++
++#define memdbg(lvl, fmt, ...)						\
++	do {								\
++		if(memdbg_enable >= lvl)				\
++			trace_printk(fmt, ##__VA_ARGS__);		\
++	} while(0)
++
++struct palloc_stat {
++	s64 max_ns;
++	s64 min_ns;
++	s64 tot_ns;
++
++	s64 tot_cnt;
++	s64 iter_cnt;			/* avg_iter = iter_cnt / tot_cnt */
++
++	s64 cache_hit_cnt;		/* hit_rate = cache_hit_cnt / cache_acc_cnt */
++	s64 cache_acc_cnt;
++
++	s64 flush_cnt;
++
++	s64 alloc_balance;
++	s64 alloc_balance_timeout;
++	ktime_t start;			/* Start time of the current iteration */
++};
++
++static struct {
++	u32 enabled;
++	int colors;
++	struct palloc_stat stat[3]; 	/* 0 - color, 1 - normal, 2- fail */
++} palloc;
++
++static void palloc_flush(struct zone *zone);
++
++static ssize_t palloc_write(struct file *filp, const char __user *ubuf, size_t cnt, loff_t *ppos)
++{
++	char buf[64];
++	int i;
++
++	if (cnt > 63) cnt = 63;
++	if (copy_from_user(&buf, ubuf, cnt))
++		return -EFAULT;
++
++	if (!strncmp(buf, "reset", 5)) {
++		printk(KERN_INFO "reset statistics...\n");
++		for (i = 0; i < ARRAY_SIZE(palloc.stat); i++) {
++			memset(&palloc.stat[i], 0, sizeof(struct palloc_stat));
++			palloc.stat[i].min_ns = 0x7fffffff;
++		}
++	} else if (!strncmp(buf, "flush", 5)) {
++		struct zone *zone;
++		printk(KERN_INFO "flush color cache...\n");
++		for_each_populated_zone(zone) {
++			unsigned long flags;
++			if (!zone)
++				continue;
++			spin_lock_irqsave(&zone->lock, flags);
++			palloc_flush(zone);
++			spin_unlock_irqrestore(&zone->lock, flags);
++		}
++	} else if (!strncmp(buf, "xor", 3)) {
++		int bit, xor_bit;
++		sscanf(buf + 4, "%d %d", &bit, &xor_bit);
++		if ((bit > 0 && bit < 64) && (xor_bit > 0 && xor_bit < 64) && bit != xor_bit) {
++			mc_xor_bits[bit] = xor_bit;
++		}
++	}
++
++	*ppos += cnt;
++
++	return cnt;
++}
++
++static int palloc_show(struct seq_file *m, void *v)
++{
++	int i, tmp;
++	char *desc[] = { "Color", "Normal", "Fail" };
++	char buf[256];
++
++	for (i = 0; i < 3; i++) {
++		struct palloc_stat *stat = &palloc.stat[i];
++		seq_printf(m, "statistics %s:\n", desc[i]);
++		seq_printf(m, " min(ns)/max(ns)/avg(ns)/tot_cnt: %lld %lld %lld %lld\n",
++			   stat->min_ns,
++			   stat->max_ns,
++			   (stat->tot_cnt)? div64_u64(stat->tot_ns, stat->tot_cnt) : 0,
++			   stat->tot_cnt);
++		seq_printf(m, " hit rate: %lld/%lld (%lld %%)\n",
++			   stat->cache_hit_cnt, stat->cache_acc_cnt,
++			   (stat->cache_acc_cnt)? div64_u64(stat->cache_hit_cnt*100, stat->cache_acc_cnt) : 0);
++		seq_printf(m, " avg iter: %lld (%lld/%lld)\n",
++			   (stat->tot_cnt)? div64_u64(stat->iter_cnt, stat->tot_cnt) : 0,
++			   stat->iter_cnt, stat->tot_cnt);
++		seq_printf(m, " flush cnt: %lld\n", stat->flush_cnt);
++
++		seq_printf(m, " balance: %lld | fail: %lld\n",
++			   stat->alloc_balance, stat->alloc_balance_timeout);
++	}
++
++	seq_printf(m, "mask: 0x%lx\n", sysctl_palloc_mask);
++
++	tmp = bitmap_weight(&sysctl_palloc_mask, sizeof(unsigned long)*8);
++
++	seq_printf(m, "weight: %d (bins: %d)\n", tmp, (1 << tmp));
++
++	scnprintf(buf, 256, "%*pbl", (int)(sizeof(unsigned long) * 8), &sysctl_palloc_mask);
++
++	seq_printf(m, "bits: %s\n", buf);
++
++	seq_printf(m, "XOR bits: %s\n", (use_mc_xor)? "enabled" : "disabled");
++
++	for (i = 0; i < 64; i++) {
++		if (mc_xor_bits[i] > 0)
++			seq_printf(m, "    %3d <-> %3d\n", i, mc_xor_bits[i]);
++	}
++
++	seq_printf(m, "Use PALLOC: %s\n", (use_palloc)? "enabled" : "disabled");
++
++	return 0;
++}
++
++static int palloc_open(struct inode *inode, struct file *filp)
++{
++	return single_open(filp, palloc_show, NULL);
++}
++
++static const struct file_operations palloc_fops = {
++	.open		= palloc_open,
++	.write		= palloc_write,
++	.read		= seq_read,
++	.llseek		= seq_lseek,
++	.release	= single_release,
++};
++
++static int __init palloc_debugfs(void)
++{
++	umode_t mode = S_IFREG | S_IRUSR | S_IWUSR;
++	struct dentry *dir;
++	int i;
++
++	dir = debugfs_create_dir("palloc", NULL);
++
++	/* Statistics Initialization */
++	for (i = 0; i < ARRAY_SIZE(palloc.stat); i++) {
++		memset(&palloc.stat[i], 0, sizeof(struct palloc_stat));
++		palloc.stat[i].min_ns = 0x7fffffff;
++	}
++
++	if (!dir)
++		return PTR_ERR(dir);
++	if (!debugfs_create_file("control", mode, dir, NULL, &palloc_fops))
++		goto fail;
++	if (!debugfs_create_u64("palloc_mask", mode, dir, (u64 *)&sysctl_palloc_mask))
++		goto fail;
++	if (!debugfs_create_u32("use_mc_xor", mode, dir, &use_mc_xor))
++		goto fail;
++	if (!debugfs_create_u32("use_palloc", mode, dir, &use_palloc))
++		goto fail;
++	if (!debugfs_create_u32("debug_level", mode, dir, &memdbg_enable))
++		goto fail;
++	return 0;
++
++fail:
++	debugfs_remove_recursive(dir);
++	return -ENOMEM;
++}
++
++late_initcall(palloc_debugfs);
++
++#endif /* CONFIG_CGROUP_PALLOC */
++
+ #define MIN_PERCPU_PAGELIST_FRACTION	(8)
+ 
+ #ifdef CONFIG_USE_PERCPU_NUMA_NODE_ID
+@@ -1402,6 +1590,323 @@ static int prep_new_page(struct page *page, unsigned int order, gfp_t gfp_flags,
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_CGROUP_PALLOC
++
++int palloc_bins(void)
++{
++	return min((1 << bitmap_weight(&sysctl_palloc_mask, sizeof(unsigned long) * 8)), MAX_PALLOC_BINS);
++}
++
++static inline int page_to_color(struct page *page)
++{
++	int color = 0;
++	int idx = 0;
++	int c;
++
++	unsigned long paddr = page_to_phys(page);
++	for_each_set_bit(c, &sysctl_palloc_mask, sizeof(unsigned long) * 8) {
++		if (use_mc_xor) {
++			if (((paddr >> c) & 0x1) ^ ((paddr >> mc_xor_bits[c]) & 0x1))
++				color |= (1 << idx);
++		} else {
++			if ((paddr >> c) & 0x1)
++				color |= (1 << idx);
++		}
++
++		idx++;
++	}
++
++	return color;
++}
++
++/* Debug */
++static inline unsigned long list_count(struct list_head *head)
++{
++	unsigned long n = 0;
++	struct list_head *curr;
++
++	list_for_each(curr, head)
++		n++;
++
++	return n;
++}
++
++/* Move all color_list pages into free_area[0].freelist[2]
++ * zone->lock must be held before calling this function
++ */
++static void palloc_flush(struct zone *zone)
++{
++	int c;
++	struct page *page;
++
++	memdbg(2, "Flush the color-cache for zone %s\n", zone->name);
++
++	while(1) {
++		for (c = 0; c < MAX_PALLOC_BINS; c++) {
++			if (!list_empty(&zone->color_list[c])) {
++				page = list_entry(zone->color_list[c].next, struct page, lru);
++				list_del_init(&page->lru);
++				__free_one_page(page, page_to_pfn(page), zone, 0, get_pageblock_migratetype(page));
++				zone->free_area[0].nr_free--;
++			}
++
++			if (list_empty(&zone->color_list[c])) {
++				bitmap_clear(zone->color_bitmap, c, 1);
++				INIT_LIST_HEAD(&zone->color_list[c]);
++			}
++		}
++
++		if (bitmap_weight(zone->color_bitmap, MAX_PALLOC_BINS) == 0)
++			break;
++	}
++}
++
++/* Move a page (size = 1 << order) into order-0 colored cache */
++static void palloc_insert(struct zone *zone, struct page *page, int order)
++{
++	int i, color;
++
++	/* 1 page (2^order) -> 2^order x pages of colored cache.
++	   Remove from zone->free_area[order].free_list[mt] */
++	list_del(&page->lru);
++	zone->free_area[order].nr_free--;
++
++	/* Insert pages to zone->color_list[] (all order-0) */
++	for (i = 0; i < (1 << order); i++) {
++		color = page_to_color(&page[i]);
++
++		/* Add to zone->color_list[color] */
++		memdbg(5, "- Add pfn %ld (0x%08llx) to color_list[%d]\n", page_to_pfn(&page[i]), (u64)page_to_phys(&page[i]), color);
++
++		INIT_LIST_HEAD(&page[i].lru);
++		list_add_tail(&page[i].lru, &zone->color_list[color]);
++		bitmap_set(zone->color_bitmap, color, 1);
++		zone->free_area[0].nr_free++;
++		rmv_page_order(&page[i]);
++	}
++
++	memdbg(4, "Add order=%d zone=%s\n", order, zone->name);
++
++	return;
++}
++
++/* Return a colored page (order-0) and remove it from the colored cache */
++static inline struct page *palloc_find_cmap(struct zone *zone, COLOR_BITMAP(cmap), int order, struct palloc_stat *stat)
++{
++	struct page *page;
++	COLOR_BITMAP(tmpmask);
++	int c;
++	unsigned int tmp_idx;
++	int found_w, want_w;
++	unsigned long rand_seed;
++
++	/* Cache Statistics */
++	if (stat) stat->cache_acc_cnt++;
++
++	/* Find color cache entry */
++	if (!bitmap_intersects(zone->color_bitmap, cmap, MAX_PALLOC_BINS))
++		return NULL;
++
++	bitmap_and(tmpmask, zone->color_bitmap, cmap, MAX_PALLOC_BINS);
++
++	/* Must have a balance */
++	found_w = bitmap_weight(tmpmask, MAX_PALLOC_BINS);
++	want_w  = bitmap_weight(cmap, MAX_PALLOC_BINS);
++
++	if (sysctl_alloc_balance && (found_w < want_w) && (found_w < min(sysctl_alloc_balance, want_w)) && memdbg_enable) {
++		ktime_t dur = ktime_sub(ktime_get(), stat->start);
++		if (dur.tv64 < 1000000) {
++			/* Try to balance unless order = MAX-2 or 1ms has passed */
++			memdbg(4, "found_w=%d want_w=%d order=%d elapsed=%lld ns\n", found_w, want_w, order, dur.tv64);
++
++			stat->alloc_balance++;
++
++			return NULL;
++		}
++
++		stat->alloc_balance_timeout++;
++	}
++
++	/* Choose a bit among the candidates */
++	if (sysctl_alloc_balance && memdbg_enable) {
++		rand_seed = (unsigned long)stat->start.tv64;
++	} else {
++		rand_seed = per_cpu(palloc_rand_seed, smp_processor_id())++;
++
++		if (rand_seed > MAX_PALLOC_BINS)
++			per_cpu(palloc_rand_seed, smp_processor_id()) = 0;
++	}
++
++	tmp_idx = rand_seed % found_w;
++
++	for_each_set_bit(c, tmpmask, MAX_PALLOC_BINS) {
++		if (tmp_idx-- <= 0)
++			break;
++	}
++
++	BUG_ON(c >= MAX_PALLOC_BINS);
++	BUG_ON(list_empty(&zone->color_list[c]));
++
++	page = list_entry(zone->color_list[c].next, struct page, lru);
++
++	memdbg(1, "Found colored page pfn %ld color %d seed %ld found/want %d/%d\n",
++	       page_to_pfn(page), c, rand_seed, found_w, want_w);
++
++	/* Remove the page from the zone->color_list[color] */
++	list_del(&page->lru);
++
++	if (list_empty(&zone->color_list[c]))
++		bitmap_clear(zone->color_bitmap, c, 1);
++
++	zone->free_area[0].nr_free--;
++
++	memdbg(5, "- del pfn %ld from color_list[%d]\n", page_to_pfn(page), c);
++
++	if (stat) stat->cache_hit_cnt++;
++
++	return page;
++}
++
++static inline void update_stat(struct palloc_stat *stat, struct page *page, int iters)
++{
++	ktime_t dur;
++
++	if (memdbg_enable == 0)
++		return;
++
++	dur = ktime_sub(ktime_get(), stat->start);
++
++	if (dur.tv64 > 0) {
++		stat->min_ns = min(dur.tv64, stat->min_ns);
++		stat->max_ns = max(dur.tv64, stat->max_ns);
++
++		stat->tot_ns += dur.tv64;
++		stat->iter_cnt += iters;
++
++		stat->tot_cnt++;
++
++		memdbg(2, "order %ld pfn %ld (0x%08llx) color %d iters %d in %lld ns\n",
++		       (long int)page_order(page), (long int)page_to_pfn(page), (u64)page_to_phys(page),
++		       (int)page_to_color(page), iters, dur.tv64);
++	} else {
++		memdbg(5, "dur %lld is < 0\n", dur.tv64);
++	}
++
++	return;
++}
++
++/*
++ * Go through the free lists for the given migratetype and remove
++ * the smallest available page from the freelists
++ */
++static inline
++struct page *__rmqueue_smallest(struct zone *zone, unsigned int order,
++						int migratetype)
++{
++	unsigned int current_order;
++	struct free_area *area;
++	struct list_head *curr, *tmp;
++	struct page *page;
++
++	struct palloc *ph;
++	struct palloc_stat *c_stat = &palloc.stat[0];
++	struct palloc_stat *n_stat = &palloc.stat[1];
++	struct palloc_stat *f_stat = &palloc.stat[2];
++
++	int iters = 0;
++	COLOR_BITMAP(tmpcmap);
++	unsigned long *cmap;
++
++	if (memdbg_enable)
++		c_stat->start = n_stat->start = f_stat->start = ktime_get();
++
++	if (!use_palloc)
++		goto normal_buddy_alloc;
++
++	/* cgroup information */
++	ph = ph_from_subsys(current->cgroups->subsys[palloc_cgrp_id]);
++
++	if (ph && bitmap_weight(ph->cmap, MAX_PALLOC_BINS) > 0)
++		cmap = ph->cmap;
++	else {
++		bitmap_fill(tmpcmap, MAX_PALLOC_BINS);
++		cmap = tmpcmap;
++	}
++
++	page = NULL;
++	if (order == 0) {
++		/* Find page in the color cache */
++		memdbg(5, "check color cache (mt=%d)\n", migratetype);
++
++		page = palloc_find_cmap(zone, cmap, 0, c_stat);
++
++		if (page) {
++			update_stat(c_stat, page, iters);
++			return page;
++		}
++	}
++
++	if (order == 0) {
++		/* Build Color Cache */
++		iters++;
++
++		/* Search the entire list. Make color cache in the process */
++		for (current_order = 0; current_order < MAX_ORDER; ++current_order) {
++			area = &(zone->free_area[current_order]);
++
++			if (list_empty(&area->free_list[migratetype]))
++				continue;
++
++			memdbg(3, " order=%d (nr_free=%ld)\n", current_order, area->nr_free);
++
++			list_for_each_safe(curr, tmp, &area->free_list[migratetype]) {
++				iters++;
++				page = list_entry(curr, struct page, lru);
++				palloc_insert(zone, page, current_order);
++				page = palloc_find_cmap(zone, cmap, current_order, c_stat);
++
++				if (page) {
++					update_stat(c_stat, page, iters);
++					memdbg(1, "Found at Zone %s pfn 0x%lx\n", zone->name, page_to_pfn(page));
++
++					return page;
++				}
++			}
++		}
++
++		memdbg(1, "Failed to find a matching color\n");
++	} else {
++normal_buddy_alloc:
++		/* Normal Buddy Algorithm */
++		/* Find a page of the specified size in the preferred list */
++		for (current_order = order; current_order < MAX_ORDER; ++current_order) {
++			area = &(zone->free_area[current_order]);
++			iters++;
++
++			if (list_empty(&area->free_list[migratetype]))
++				continue;
++
++			page = list_entry(area->free_list[migratetype].next, struct page, lru);
++
++			list_del(&page->lru);
++			rmv_page_order(page);
++			area->nr_free--;
++			expand(zone, page, order, current_order, area, migratetype);
++
++			update_stat(n_stat, page, iters);
++
++			return page;
++		}
++	}
++
++	/* No memory (colored or normal) found in this zone */
++	memdbg(1, "No memory in Zone %s: order %d mt %d\n", zone->name, order, migratetype);
++
++	return NULL;
++}
++
++#else /* CONFIG_CGROUP_PALLOC */
++
+ /*
+  * Go through the free lists for the given migratetype and remove
+  * the smallest available page from the freelists
+@@ -1433,6 +1938,7 @@ struct page *__rmqueue_smallest(struct zone *zone, unsigned int order,
+ 	return NULL;
+ }
+ 
++#endif /* CONFIG_CGROUP_PALLOC */
+ 
+ /*
+  * This array describes the order lists are fallen back to when
+@@ -2195,8 +2701,12 @@ struct page *buffered_rmqueue(struct zone *preferred_zone,
+ 	unsigned long flags;
+ 	struct page *page;
+ 	bool cold = ((gfp_flags & __GFP_COLD) != 0);
++	struct palloc *ph;
++
++	ph = ph_from_subsys(current->cgroups->subsys[palloc_cgrp_id]);
+ 
+-	if (likely(order == 0)) {
++	/* Skip PCP when physical memory aware allocation is requested */
++	if (likely(order == 0) && !ph) {
+ 		struct per_cpu_pages *pcp;
+ 		struct list_head *list;
+ 
+@@ -4520,6 +5030,17 @@ void __meminit memmap_init_zone(unsigned long size, int nid, unsigned long zone,
+ static void __meminit zone_init_free_lists(struct zone *zone)
+ {
+ 	unsigned int order, t;
++
++#ifdef CONFIG_CGROUP_PALLOC
++	int c;
++
++	for (c = 0; c < MAX_PALLOC_BINS; c++) {
++		INIT_LIST_HEAD(&zone->color_list[c]);
++	}
++
++	bitmap_zero(zone->color_bitmap, MAX_PALLOC_BINS);
++#endif /* CONFIG_CGROUP_PALLOC */
++
+ 	for_each_migratetype_order(order, t) {
+ 		INIT_LIST_HEAD(&zone->free_area[order].free_list[t]);
+ 		zone->free_area[order].nr_free = 0;
+@@ -6854,6 +7375,11 @@ __offline_isolated_pages(unsigned long start_pfn, unsigned long end_pfn)
+ 		return;
+ 	zone = page_zone(pfn_to_page(pfn));
+ 	spin_lock_irqsave(&zone->lock, flags);
++
++#ifdef CONFIG_CGROUP_PALLOC
++	palloc_flush(zone);
++#endif
++
+ 	pfn = start_pfn;
+ 	while (pfn < end_pfn) {
+ 		if (!pfn_valid(pfn)) {
+diff --git a/mm/palloc.c b/mm/palloc.c
+new file mode 100644
+index 0000000..bc6a341
+--- /dev/null
++++ b/mm/palloc.c
+@@ -0,0 +1,173 @@
++/**
++ * kernel/palloc.c
++ *
++ * Color Aware Physical Memory Allocator User-Space Information
++ *
++ */
++
++#include <linux/types.h>
++#include <linux/cgroup.h>
++#include <linux/kernel.h>
++#include <linux/slab.h>
++#include <linux/palloc.h>
++#include <linux/mm.h>
++#include <linux/err.h>
++#include <linux/fs.h>
++#include <linux/bitmap.h>
++#include <linux/module.h>
++
++/**
++ * Check if a page is compliant with the policy defined for the given vma
++ */
++#ifdef CONFIG_CGROUP_PALLOC
++
++#define MAX_LINE_LEN (6 * 128)
++
++/**
++ * Type of files in a palloc group
++ * FILE_PALLOC - contains list of palloc bins allowed
++ */
++typedef enum {
++	FILE_PALLOC,
++} palloc_filetype_t;
++
++/**
++ * Retrieve the palloc group corresponding to this cgroup container
++ */
++struct palloc *cgroup_ph(struct cgroup *cgrp)
++{
++	return container_of(cgrp->subsys[palloc_cgrp_id], struct palloc, css);
++}
++
++struct palloc *ph_from_subsys(struct cgroup_subsys_state *subsys)
++{
++	return container_of(subsys, struct palloc, css);
++}
++
++/**
++ * Common write function for files in palloc cgroup
++ */
++static int update_bitmask(unsigned long *bitmap, const char *buf, int maxbits)
++{
++	int retval = 0;
++
++	if (!*buf)
++		bitmap_clear(bitmap, 0, maxbits);
++	else
++		retval = bitmap_parselist(buf, bitmap, maxbits);
++
++	return retval;
++}
++
++static ssize_t palloc_file_write(struct kernfs_open_file *of, char *buf, size_t nbytes, loff_t off)
++{
++	struct cgroup_subsys_state *css;
++	struct cftype *cft;
++	int retval = 0;
++	struct palloc *ph;
++
++	css = of_css(of);
++	cft = of_cft(of);
++	ph = container_of(css, struct palloc, css);
++
++	switch (cft->private) {
++		case FILE_PALLOC:
++			retval = update_bitmask(ph->cmap, buf, palloc_bins());
++			printk(KERN_INFO "Bins : %s\n", buf);
++			break;
++
++		default:
++			retval = -EINVAL;
++			break;
++	}
++
++	return retval? :nbytes;
++}
++
++static int palloc_file_read(struct seq_file *sf, void *v)
++{
++	struct cgroup_subsys_state *css = seq_css(sf);
++	struct cftype *cft = seq_cft(sf);
++	struct palloc *ph = container_of(css, struct palloc, css);
++	char *page;
++	ssize_t retval = 0;
++	char *s;
++
++	if (!(page = (char *)__get_free_page(GFP_TEMPORARY | __GFP_ZERO)))
++		return -ENOMEM;
++
++	s = page;
++
++	switch (cft->private) {
++		case FILE_PALLOC:
++			s += scnprintf(s, PAGE_SIZE, "%*pbl", (int)palloc_bins(), ph->cmap);
++			*s++ = '\n';
++			printk(KERN_INFO "Bins : %s", page);
++			break;
++
++		default:
++			retval = -EINVAL;
++			goto out;
++	}
++
++	seq_printf(sf, "%s", page);
++
++out:
++	free_page((unsigned long)page);
++	return retval;
++}
++
++/**
++ * struct cftype : handler definitions for cgroup control files
++ *
++ * for the common functions, 'private' gives the type of the file
++ */
++static struct cftype files[] = {
++	{
++		.name 		= "bins",
++		.seq_show	= palloc_file_read,
++		.write		= palloc_file_write,
++		.max_write_len	= MAX_LINE_LEN,
++		.private	= FILE_PALLOC,
++	},
++	{}
++};
++
++
++/**
++ * palloc_create - create a palloc group
++ */
++static struct cgroup_subsys_state *palloc_create(struct cgroup_subsys_state *css)
++{
++	struct palloc *ph_child;
++
++	ph_child = kmalloc(sizeof(struct palloc), GFP_KERNEL);
++
++	if (!ph_child)
++		return ERR_PTR(-ENOMEM);
++
++	bitmap_clear(ph_child->cmap, 0, MAX_PALLOC_BINS);
++
++	return &ph_child->css;
++}
++
++/**
++ * Destroy an existing palloc group
++ */
++static void palloc_destroy(struct cgroup_subsys_state *css)
++{
++	struct palloc *ph = container_of(css, struct palloc, css);
++
++	kfree(ph);
++}
++
++struct cgroup_subsys palloc_cgrp_subsys = {
++	.name		= "palloc",
++	.css_alloc	= palloc_create,
++	.css_free	= palloc_destroy,
++	.id		= palloc_cgrp_id,
++	.dfl_cftypes	= files,
++	.legacy_cftypes	= files,
++};
++
++#endif /* CONFIG_CGROUP_PALLOC */
+diff --git a/mm/vmstat.c b/mm/vmstat.c
+index c54fd29..2c8e1d1 100644
+--- a/mm/vmstat.c
++++ b/mm/vmstat.c
+@@ -28,6 +28,10 @@
+ #include <linux/page_ext.h>
+ #include <linux/page_owner.h>
+ 
++#ifdef CONFIG_CGROUP_PALLOC
++#include <linux/palloc.h>
++#endif
++
+ #include "internal.h"
+ 
+ #ifdef CONFIG_VM_EVENT_COUNTERS
+@@ -937,6 +941,44 @@ static void frag_show_print(struct seq_file *m, pg_data_t *pgdat,
+ {
+ 	int order;
+ 
++#ifdef CONFIG_CGROUP_PALLOC
++	int color, mt, cnt, bins;
++	struct free_area *area;
++	struct list_head *curr;
++
++	seq_printf(m, "--------\n");
++
++	/* Order by memory type */
++	for (mt = 0; mt < MIGRATE_ISOLATE; mt++) {
++		seq_printf(m, "-%17s[%d]", "mt", mt);
++		for (order = 0; order < MAX_ORDER; order++) {
++			area = &(zone->free_area[order]);
++			cnt  = 0;
++
++			list_for_each(curr, &area->free_list[mt])
++				cnt++;
++
++			seq_printf(m, "%6d ", cnt);
++		}
++
++		seq_printf(m, "\n");
++	}
++
++	/* Order by color */
++	seq_printf(m, "--------\n");
++	bins = palloc_bins();
++
++	for (color = 0; color < bins; color++) {
++		seq_printf(m, "- color [%d:%0x]", color, color);
++		cnt = 0;
++
++		list_for_each(curr, &zone->color_list[color])
++			cnt++;
++
++		seq_printf(m, "%6d\n", cnt);
++	}
++#endif /* CONFIG_CGROUP_PALLOC */
++
+ 	seq_printf(m, "Node %d, zone %8s ", pgdat->node_id, zone->name);
+ 	for (order = 0; order < MAX_ORDER; ++order)
+ 		seq_printf(m, "%6lu ", zone->free_area[order].nr_free);


### PR DESCRIPTION
This pull-request adds the PALLOC patch for Linux-4.4.3 kernel. The patch has been verified to be working (i.e. effective cache-coloring).
Please see the comment added to the log of this commit to find out the exact details of this patch.
